### PR TITLE
add three.js JSON format 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported file formats:
 * [OBJ](https://en.wikipedia.org/wiki/Wavefront_.obj_file)
 * [AMF](http://en.wikipedia.org/wiki/Additive_Manufacturing_File_Format)
 * [OFF](https://en.wikipedia.org/wiki/OFF_%28file_format%29)
+* [threejs](https://github.com/mrdoob/three.js/wiki/JSON-Model-format-3)
 
 Meshes can be imported with the following function.
 
@@ -30,6 +31,7 @@ By default the function autodetects the file format for you. You can specify a f
 * `:asciistl`
 * `:amf`
 * `:off`
+* `:threejs`
 
 By default we do not check topology for repeat vertices since it can be computationally expensive. If `topology` is set to `true`, repeat vertices are eliminated so the `Mesh` is a proper [face-vertex](https://en.wikipedia.org/wiki/Polygon_mesh#Face-vertex_meshes) polygon mesh.
 
@@ -39,6 +41,7 @@ Support export formats:
 * [Aquaveo-SMS 2DM](http://www.xmswiki.com/xms/SMS:2D_Mesh_Files_*.2dm)
 * [ASCII PLY](https://en.wikipedia.org/wiki/PLY)
 * [OFF](https://en.wikipedia.org/wiki/OFF_%28file_format%29)
+Ä [threejs](https://github.com/mrdoob/three.js/wiki/JSON-Model-format-3)
 
 ## Coming soon, hopefully...
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ DataStructures
 ZipFile
 LightXML
 Lint
+JSON

--- a/src/io.jl
+++ b/src/io.jl
@@ -4,6 +4,7 @@ include("io/obj.jl")
 include("io/off.jl")
 include("io/ply.jl")
 include("io/stl.jl")
+include("io/threejs.jl")
 
 using ZipFile
 
@@ -32,6 +33,8 @@ function mesh(path::String; format=:autodetect, topology=false)
             fmt = :amf
         elseif endswith(path, ".off")
             fmt = :off
+        elseif endswith(path, ".js")
+            fmt = :threejs
         else
             error("Could not identify mesh format")
         end
@@ -59,6 +62,8 @@ function mesh(path::String; format=:autodetect, topology=false)
         msh = importAMF(io)
     elseif fmt == :off
         msh = importOFF(io)
+    elseif fmt == :threejs
+        msh = importThreejs(io)
     else
         error("Could not identify mesh format")
     end

--- a/src/io/threejs.jl
+++ b/src/io/threejs.jl
@@ -1,0 +1,144 @@
+# https://github.com/mrdoob/three.js/wiki/JSON-Model-format-3
+
+import JSON
+export exportToThreejs,
+		importThreejs
+
+
+function exportToThreejs( msh::Mesh, fn::String )
+	vts = msh.vertices
+    fcs = msh.faces
+    nV = size(vts,1)
+    nF = size(fcs,1)
+
+	json = Dict()
+
+	json["faces"] = Int64[]
+	for i=1:nF
+		push!( json["faces"], 0, fcs[i].v1-1, fcs[i].v2-1, fcs[i].v3-1 )
+	end
+
+	json["vertices"] = Float64[]
+	for i=1:nV
+		push!( json["vertices"], vts[i].e1, vts[i].e2, vts[i].e3 )
+	end
+
+	json["metadata"] = Dict()
+	json["metadata"]["formatVersion"] = 3
+
+	str = open(fn,"w")
+	write(str, JSON.json( json ) )
+	close(str)
+end
+
+
+function importThreejs( fn::String, topology=true )
+
+	json = JSON.parsefile( fn )
+
+    if ( !haskey(json,"metadata") || !haskey(json["metadata"],"formatVersion") || !(json["metadata"]["formatVersion"] in [3,3.1] ) )
+
+        println( "Only formats 3 and 3.1 supported." );
+        return;
+
+    end
+
+	function isBitSet( value, position )
+
+		return ( value & ( 1 << position ) ) > 0;
+
+ 	end
+
+	vts = Vertex[]
+    fcs = Face[]
+
+    nV = length( json["vertices"] )
+
+	for i=1:3:nV
+
+		push!( vts, Vertex( json["vertices"][i], json["vertices"][i+1], json["vertices"][i+2] ) )
+
+    end
+
+    i = 1;
+    zLength = length( json["faces"] );
+
+    while i <= zLength 
+
+        facetype = json["faces"][i]
+       	i += 1
+
+        isQuad              = isBitSet( facetype, 0 )
+        hasMaterial         = isBitSet( facetype, 1 )
+        hasFaceUv           = isBitSet( facetype, 2 )
+        hasFaceVertexUv     = isBitSet( facetype, 3 )
+        hasFaceNormal       = isBitSet( facetype, 4 )
+        hasFaceVertexNormal = isBitSet( facetype, 5 )
+        hasFaceColor        = isBitSet( facetype, 6 )
+        hasFaceVertexColor  = isBitSet( facetype, 7 )
+
+        if ( isQuad )
+
+        	# convert quad to two tri
+        	push!( fcs, Face( json["faces"][i]+1, json["faces"][i+1]+1, json["faces"][i+2]+1 ) )
+        	push!( fcs, Face( json["faces"][i]+1, json["faces"][i+2]+1, json["faces"][i+3]+1 ) )
+        	i += 4
+        	nVertices = 4
+
+        else
+
+        	push!( fcs, Face( json["faces"][i]+1, json["faces"][i+1]+1, json["faces"][i+2]+1 ) )
+        	i += 3
+        	nVertices = 3
+
+        end
+
+        if ( hasMaterial )
+
+        	i += 1
+
+        end
+
+        if ( hasFaceUv )
+
+        	i += 1
+
+        end
+
+        if ( hasFaceVertexUv )
+
+        	i += nVertices
+
+        end
+
+        if ( hasFaceNormal )
+
+        	i += 1
+
+        end
+
+        if ( hasFaceVertexNormal )
+
+        	i += nVertices
+
+        end
+
+        if ( hasFaceColor )
+
+        	i += 1
+
+        end
+
+        if ( hasFaceVertexColor )
+
+        	i += nVertices
+
+        end
+
+    end
+
+    topology = false
+
+    return Mesh(vts, fcs, topology)
+
+end


### PR DESCRIPTION
Added import and export for three.js JSON format 3 described in
https://github.com/mrdoob/three.js/wiki/JSON-Model-format-3

Support now only for vertices and faces.  Hopefully in the future more can be supported as a result of #21.  Possible would be material, uvs, vertex uvs, normal, vertex normals, color, vertex colors. and morphtargets. 
