### PR TITLE
Use printf instead of sprintf for exporting to STL

### DIFF
--- a/src/io/stl.jl
+++ b/src/io/stl.jl
@@ -21,20 +21,16 @@ function exportToStl(msh::Mesh, str::IO, closeAfterwards::Bool)
     for i = 1:nF
         f = fcs[i]
         n = [0,0,0] # TODO: properly compute normal(f)
-        txt = @sprintf "  facet normal %e %e %e\n" n[1] n[2] n[3]
-        write(str,txt)
+        @printf str "  facet normal %e %e %e\n" n[1] n[2] n[3]
         write(str,"    outer loop\n")
         v = vts[f.v1]
-        txt = @sprintf "      vertex  %e %e %e\n" v[1] v[2] v[3]
-        write(str,txt)
+        @printf str "      vertex  %e %e %e\n" v[1] v[2] v[3]
 
         v = vts[f.v2]
-        txt = @sprintf "      vertex  %e %e %e\n" v[1] v[2] v[3]
-        write(str,txt)
+        @printf str "      vertex  %e %e %e\n" v[1] v[2] v[3]
 
         v = vts[f.v3]
-        txt = @sprintf "      vertex  %e %e %e\n" v[1] v[2] v[3]
-        write(str,txt)
+        @printf str "      vertex  %e %e %e\n" v[1] v[2] v[3]
 
         write(str,"    endloop\n")
         write(str,"  endfacet\n")


### PR DESCRIPTION
In theory this speeds things up by avoiding allocation. In practice, grisu is the bottleneck, at least on 0.4. I will comment further on #25, but this should be an improvement regardless.
