### PR TITLE
Export Tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ include("test_types.jl")
 include("test_meshes.jl")
 include("test_imports.jl")
 include("test_slice.jl")
+include("test_exports.jl")
 
 # run lint
 println("Running Lint...")

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -1,0 +1,14 @@
+using Meshes
+using Base.Test
+
+data_path = Pkg.dir("Meshes")*"/test/data/"
+
+cube = mesh(data_path*"cube_binary.stl", topology=true)
+o = IOBuffer()
+exportStl(cube, "foo.stl")
+expected = """Paths([
+    Path([(58,58), (-8,58), (-8,-8), (58,-8)]),
+    Path([(18,2), (2,2), (2,10), (18,10)])
+)"""
+@show ASCIIString(o.data)
+@test ASCIIString(o.data) == expected


### PR DESCRIPTION
The biggest reason coverage is <80% is because of no export tests. Before the File API is refactored, we should have comprehensive tests. 
