### PR TITLE
Speed up slice, backport to v0.1.x

### DIFF
--- a/src/slice.jl
+++ b/src/slice.jl
@@ -1,7 +1,3 @@
-function Base.(:(==))(a::Vector2, b::Vector2)
-    return a[1] == b[1] && a[2] == b[2]
-end
-
 # TODO Return type channges based on pair value
 function Base.slice(mesh::Mesh{Vector3{Float64}, Face{Int}}, heights::Vector{Float64}, pair=true; eps=0.00001, autoeps=true)
 

--- a/src/slice.jl
+++ b/src/slice.jl
@@ -1,3 +1,7 @@
+function Base.(:(==))(a::Vector2, b::Vector2)
+    return a[1] == b[1] && a[2] == b[2]
+end
+
 # TODO Return type channges based on pair value
 function Base.slice(mesh::Mesh{Vector3{Float64}, Face{Int}}, heights::Vector{Float64}, pair=true; eps=0.00001, autoeps=true)
 
@@ -77,7 +81,7 @@ function Base.slice(mesh::Mesh{Vector3{Float64}, Face{Int}}, heights::Vector{Flo
             end
         end
 
-        while true
+        @inbounds while true
             #Start new polygon with seg
             poly = @compat Tuple{Vector2{Float64}, Vector2{Float64}}[]
             push!(poly, lines[seg])

--- a/src/slice.jl
+++ b/src/slice.jl
@@ -66,7 +66,7 @@ function Base.slice(mesh::Mesh{Vector3{Float64}, Face{Int}}, heights::Vector{Flo
             continue
         end
         polys = Vector{@compat Tuple{Vector2{Float64}, Vector2{Float64}}}[]
-        paired = falses(line_ct)
+        paired = fill(false, line_ct)
         start = 1
         seg = 1
         paired[seg] = true


### PR DESCRIPTION
Just a few very low hanging performance fruits. I tried a few other
modifications that seemed plausible, but couldn't get it much faster.
Essentially all the time is currently spent it in BitArray set query
for `paired[i]`.
